### PR TITLE
Fix for bug-43

### DIFF
--- a/src/banking/primitive/core/Savings.java
+++ b/src/banking/primitive/core/Savings.java
@@ -36,7 +36,7 @@ public class Savings extends Account {
 			if (numWithdraws > 3)
 				balance = balance - 1.0f;
 			// KG BVA: should be < 0
-			if (balance <= 0.0f) {
+			if (balance < 0.0f) { //0.0f is not overdrawn so this is changed to strictly less than.
 				setState(State.OVERDRAWN);
 			}
 			return true;


### PR DESCRIPTION
This bug is checking for balance <= 0.0f is incorrect because 0.0f is
not overdrawn this incorrectly marks a balance with 0.0f as being
overdrawn.
